### PR TITLE
feat: extend `check cmd` with inclusion and exclusion checks

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -16,41 +16,53 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Define constants for the different checks to avoid hardcoded strings
+const (
+	CheckSorting     = "sorting"
+	CheckDuplicates  = "duplicates"
+	CheckEmptyValues = "emptyValues"
+	CheckUnused      = "unused"
+)
+
+// Define a list of all available checks
+var allChecks = []string{
+	CheckSorting,
+	CheckDuplicates,
+	CheckEmptyValues,
+	CheckUnused,
+}
+
+// Define options for different checks and flags
 type CheckOptions struct {
 	exitOnIssue     bool
 	stringsPath     string
 	swiftDirectory  string
 	baseStringsPath string
 	ignorePatterns  []string
-
-	checkSorting     bool
-	checkDuplicates  bool
-	checkEmptyValues bool
-	checkUnused      bool
+	includeChecks   []string
+	excludeChecks   []string
 }
 
-var checkOptions CheckOptions = CheckOptions{
+// Initialize the CheckOptions struct
+var checkOptions = CheckOptions{
 	exitOnIssue: true,
 }
 
 var checkCmd = &cobra.Command{
-	Use:   "check -b [path to base strings file] -d [path to Swift directory] [path to strings file(s)] ",
+	Use:   "check -b [path to base strings file] -d [path to Swift directory] [path to strings file(s)]",
 	Short: "Check for issues in .strings files",
 	Example: heredoc.Doc(`
 		# Run all checks (sorting, duplicates, empty values, unused keys):
-		$ xcs check
+		$ ./xcs check
 
-		# Run only the sorting check:
-		$ xcs check --check-sorting
+		# Include only sorting and duplicates checks:
+		$ ./xcs check --include sorting --include duplicates
 
-		# Run the sorting and duplicate checks only:
-		$ xcs check --check-sorting --check-duplicates
+		# Exclude sorting check:
+		$ ./xcs check --exclude sorting
 
-		# Specify a base Localizable.strings file and a Swift directory:
-		$ xcs check -b ./Base.lproj/Localizable.strings -d ./Sources
-
-		# Specify a strings file to check and ignore certain patterns:
-		$ xcs check -b ./Base.lproj/Localizable.strings -d ./Sources --ignore "test/*,docs/*"
+		# Exclude both sorting and duplicate checks:
+		$ ./xcs check --exclude sorting --exclude duplicates
 	`),
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -61,33 +73,61 @@ var checkCmd = &cobra.Command{
 			checkOptions.stringsPath = constants.DefaultStringsGlob
 		}
 
-		if checkOptions.baseStringsPath == "" && checkOptions.checkUnused {
+		// Check if the unused key check requires a base strings file
+		if checkOptions.baseStringsPath == "" && contains(checkOptions.includeChecks, CheckUnused) {
 			return fmt.Errorf("base Localizable.strings file is required for unused key check")
 		}
 
+		// Set a default swift directory if not specified
 		if checkOptions.swiftDirectory == "" {
 			checkOptions.swiftDirectory = "."
 		}
-		// check if any `--check` flag was set
-		checkSortingFlag := cmd.Flags().Changed("check-sorting")
-		checkDuplicatesFlag := cmd.Flags().Changed("check-duplicates")
-		checkEmptyValuesFlag := cmd.Flags().Changed("check-empty-values")
-		checkUnusedFlag := cmd.Flags().Changed("check-unused")
 
-		// if no `--check` flag was set, set all check.options to true
-		if !checkSortingFlag && !checkDuplicatesFlag && !checkEmptyValuesFlag && !checkUnusedFlag {
-			checkOptions.checkSorting = true
-			checkOptions.checkDuplicates = true
-			checkOptions.checkEmptyValues = true
-			checkOptions.checkUnused = true
+		// Ensure that both `--include` and `--exclude` are not used simultaneously
+		if len(checkOptions.includeChecks) > 0 && len(checkOptions.excludeChecks) > 0 {
+			return fmt.Errorf("you cannot use both --include and --exclude flags at the same time")
 		}
 
+		// Create a map to track the active status of each check
+		activeChecks := make(map[string]bool)
+		for _, check := range allChecks {
+			activeChecks[check] = true // Enable all checks by default
+		}
+
+		// If `--include` is used, only enable the specified checks
+		if len(checkOptions.includeChecks) > 0 {
+			// Disable all checks first
+			for _, check := range allChecks {
+				activeChecks[check] = false
+			}
+			// Enable only the included checks
+			for _, includeCheck := range checkOptions.includeChecks {
+				if _, ok := activeChecks[includeCheck]; ok {
+					activeChecks[includeCheck] = true
+				} else {
+					return fmt.Errorf("unknown check to include: %s", includeCheck)
+				}
+			}
+		}
+
+		// If `--exclude` is used, disable the specified checks
+		if len(checkOptions.excludeChecks) > 0 {
+			for _, excludeCheck := range checkOptions.excludeChecks {
+				if _, ok := activeChecks[excludeCheck]; ok {
+					activeChecks[excludeCheck] = false
+				} else {
+					return fmt.Errorf("unknown check to exclude: %s", excludeCheck)
+				}
+			}
+		}
+
+		// Initialize the strings file manager
 		manager, err := localizable.NewStringsFileManager([]string{checkOptions.stringsPath})
 		if err != nil {
 			return fmt.Errorf("error initializing strings manager: %w", err)
 		}
 
-		// Start a spinner
+		// Start a spinner to provide feedback while processing
 		s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 		s.Start()
 
@@ -95,34 +135,36 @@ var checkCmd = &cobra.Command{
 		var filesWithDuplicates []*localizable.StringsFile
 		var filesWithEmptyValues []*localizable.StringsFile
 
+		// Perform the checks based on the active checks map
 		for _, file := range manager.Files {
 
 			// Check for sorting if enabled
-			if checkOptions.checkSorting && (!file.IsSorted() || !file.IsSanitized()) {
+			if activeChecks[CheckSorting] && (!file.IsSorted() || !file.IsSanitized()) {
 				unsortedFiles = append(unsortedFiles, file)
 			}
 
 			// Check for duplicates if enabled
-			if checkOptions.checkDuplicates && file.HasDuplicates() {
+			if activeChecks[CheckDuplicates] && file.HasDuplicates() {
 				filesWithDuplicates = append(filesWithDuplicates, file)
 			}
 
 			// Check for empty values if enabled
-			if checkOptions.checkEmptyValues && file.HasEmptyValues() {
+			if activeChecks[CheckEmptyValues] && file.HasEmptyValues() {
 				filesWithEmptyValues = append(filesWithEmptyValues, file)
 			}
 		}
 
 		// Check for unused keys if enabled
 		var unusedKeys []string
-		if checkOptions.checkUnused {
+		if activeChecks[CheckUnused] {
 			keysForBaseStrings := manager.GetKeysForFile(checkOptions.baseStringsPath)
 			unusedKeys = internal.FindUnusedKeysInSwiftFiles(checkOptions.swiftDirectory, keysForBaseStrings, checkOptions.ignorePatterns)
 		}
 
-		// Stop spinner before showing results
+		// Stop the spinner after processing
 		s.Stop()
 
+		// Display results for the various checks
 		if len(unsortedFiles) > 0 {
 			color.Yellow("Unsorted files (%d): ", len(unsortedFiles))
 			for _, file := range unsortedFiles {
@@ -151,6 +193,7 @@ var checkCmd = &cobra.Command{
 			}
 		}
 
+		// Determine if any issues were found and handle the exit status
 		anyIssuesOccurred := len(unsortedFiles) > 0 || len(filesWithDuplicates) > 0 || len(filesWithEmptyValues) > 0 || len(unusedKeys) > 0
 		if anyIssuesOccurred {
 			color.Red("Issues found. 🚧")
@@ -171,9 +214,8 @@ func init() {
 	checkCmd.Flags().StringVarP(&checkOptions.swiftDirectory, "swift-dir", "d", "", "Path to the directory containing Swift files (.)")
 	checkCmd.Flags().StringSliceVarP(&checkOptions.ignorePatterns, "ignore", "i", constants.DefaultIgnorePatterns, "Glob patterns for files or directories to ignore")
 
-	// Default all checks to false
-	checkCmd.Flags().BoolVar(&checkOptions.checkSorting, "check-sorting", false, "Enable or disable sorting check")
-	checkCmd.Flags().BoolVar(&checkOptions.checkDuplicates, "check-duplicates", false, "Enable or disable duplicate check")
-	checkCmd.Flags().BoolVar(&checkOptions.checkEmptyValues, "check-empty-values", false, "Enable or disable empty values check")
-	checkCmd.Flags().BoolVar(&checkOptions.checkUnused, "check-unused", false, "Enable or disable unused keys check")
+	// Flags for include and exclude lists
+	availableChecks := fmt.Sprintf("%s", allChecks)
+	checkCmd.Flags().StringSliceVar(&checkOptions.includeChecks, "include", []string{}, fmt.Sprintf("List of checks to include (%s)", availableChecks))
+	checkCmd.Flags().StringSliceVar(&checkOptions.excludeChecks, "exclude", []string{}, fmt.Sprintf("List of checks to exclude (%s)", availableChecks))
 }


### PR DESCRIPTION
```
# Include only sorting and duplicates checks:
$ ./xcs check --include sorting --include duplicates

# Exclude sorting check:
$ ./xcs check --exclude sorting

# Exclude both sorting and duplicate checks:
$ ./xcs check --exclude sorting --exclude duplicates
```